### PR TITLE
Fix version V1 api for projects with numbers

### DIFF
--- a/readthedocs/api/base.py
+++ b/readthedocs/api/base.py
@@ -157,7 +157,7 @@ class VersionResource(ModelResource):
                 % self._meta.resource_name,
                 self.wrap_view('dispatch_list'),
                 name="api_version_list"),
-            url((r"^(?P<resource_name>%s)/(?P<project_slug>[a-z-_]+)/(?P"
+            url((r"^(?P<resource_name>%s)/(?P<project_slug>[a-z-_]+[a-z0-9-_]+)/(?P"
                  r"<version_slug>[a-z0-9-_.]+)/build/$")
                 % self._meta.resource_name,
                 self.wrap_view('build_version'),


### PR DESCRIPTION
If a project contains a number in its slug (ex: e2e-tests), the API /api/v1/version/e2e-test/latest/build/ raises an exception.

The regular expression wasn't expecting any number for the project slug